### PR TITLE
fix(validation): fix initialization of validator classes

### DIFF
--- a/generic_permissions/apps.py
+++ b/generic_permissions/apps.py
@@ -30,7 +30,7 @@ class GenericPermissionsConfig(AppConfig):
         )
 
         self._init_config(
-            "GENERIC_PERMISSIONS_VALIDATOR_CLASSES", [], [ValidatorsConfig]
+            "GENERIC_PERMISSIONS_VALIDATION_CLASSES", [], [ValidatorsConfig]
         )
 
     def _init_config(self, setting_name, defaults, configs):

--- a/generic_permissions/validation.py
+++ b/generic_permissions/validation.py
@@ -46,3 +46,7 @@ class ValidatorMixin:
         ):
             validated_data = method(validated_data, context=self.context)
         return validated_data
+
+
+class PassThrough:
+    pass

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -9,7 +9,7 @@ INSTALLED_APPS = (
 
 GENERIC_PERMISSIONS_PERMISSION_CLASSES = ["generic_permissions.permissions.AllowAny"]
 GENERIC_PERMISSIONS_VISIBILITY_CLASSES = ["generic_permissions.visibilities.Any"]
-GENERIC_PERMISSIONS_VALIDATION_CLASSES = ["generic_permissions.validations.PassThrough"]
+GENERIC_PERMISSIONS_VALIDATION_CLASSES = ["generic_permissions.validation.PassThrough"]
 
 ROOT_URLCONF = "tests.urls"
 


### PR DESCRIPTION
Validations never worked.. The setting is called `GENERIC_PERMISSIONS_VALIDATION_CLASSES`, not `GENERIC_PERMISSIONS_VALIDATOR_CLASSES`