### PR TITLE
fix: add fallback for queryset of read_only related fields

### DIFF
--- a/generic_permissions/visibilities.py
+++ b/generic_permissions/visibilities.py
@@ -114,8 +114,10 @@ class VisibilityRelatedFieldMixin:
         if model_instance.pk is None:
             return None
 
-        # create a queryset with the current model instance to check visibility
-        queryset = self.queryset.filter(pk=model_instance.pk)
+        # read only fields don't have queryset, infer it from the model
+        queryset = self.queryset or type(instance).objects
+        queryset = queryset.filter(pk=model_instance.pk)
+
         for handler in VisibilitiesConfig.get_handlers(queryset.model):
             queryset = handler(queryset, self.parent._context["request"])
 


### PR DESCRIPTION
Read only fields don't have a queryset (see
https://github.com/encode/django-rest-framework/blame/77ef27f18fc7c11e1d2e5fd4aaa8acc51cda6792/rest_framework/utils/field_mapping.py#L288), so we need to provide a fallback.