### PR TITLE
fix: don't check permissions for GET requests

### DIFF
--- a/generic_permissions/permissions.py
+++ b/generic_permissions/permissions.py
@@ -39,6 +39,9 @@ class PermissionViewMixin:
 
         Called by get_object().
         """
+        if request.method == "GET":
+            return
+
         for handler in ObjectPermissionsConfig.get_handlers(
             self.get_serializer().Meta.model
         ):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -25,6 +25,7 @@ from .models import Model1, Model2
         ("post", HTTP_201_CREATED),
         ("patch", HTTP_200_OK),
         ("delete", HTTP_204_NO_CONTENT),
+        ("get", HTTP_200_OK),
     ],
 )
 @pytest.mark.parametrize("use_admin_client", [True, False])
@@ -63,7 +64,7 @@ def test_permission(
 
     url = reverse("model1-list")
 
-    if method in ["patch", "delete"]:
+    if method in ["patch", "delete", "get"]:
         url = reverse("model1-detail", args=[tm.pk])
 
     data = {"text": "bar"}
@@ -72,7 +73,7 @@ def test_permission(
 
     response = getattr(client, method)(url, data=data)
 
-    if not use_admin_client:
+    if not use_admin_client and method != "get":
         assert response.status_code == HTTP_403_FORBIDDEN
         return
 


### PR DESCRIPTION
Permissions should only deal with POST/PATCH/DELETE - GET requests should be entirely governed by the visibility layer.