### PR TITLE
fix(permissions): make sure to first check the base permissions

### DIFF
--- a/generic_permissions/permissions.py
+++ b/generic_permissions/permissions.py
@@ -23,9 +23,9 @@ class PermissionViewMixin:
         """
         Overwrite default implementation to check DGAP permissions.
         """
+        super().check_permissions(request)
         if request.method != "GET":
             self._check_permissions(request)
-        super().check_permissions(request)
 
     def _check_object_permissions(self, request, instance):
         """
@@ -43,9 +43,9 @@ class PermissionViewMixin:
         """
         Overwrite default implementation to check DGAP object permissions.
         """
+        super().check_object_permissions(request, instance)
         if request.method != "GET":
             self._check_object_permissions(request, instance)
-        super().check_object_permissions(request, instance)
 
 
 class BasePermission:

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,9 +1,18 @@
+from rest_framework.permissions import BasePermission
 from rest_framework.viewsets import ModelViewSet
 
 from generic_permissions.permissions import PermissionViewMixin
 from generic_permissions.visibilities import VisibilityViewMixin
 
 from . import models, serializers
+
+
+class BaseDenyAll(BasePermission):
+    def has_permission(self, request, view):
+        return False
+
+    def has_object_permission(self, request, view, obj):
+        return False
 
 
 class Test1ViewSet(PermissionViewMixin, VisibilityViewMixin, ModelViewSet):
@@ -14,3 +23,9 @@ class Test1ViewSet(PermissionViewMixin, VisibilityViewMixin, ModelViewSet):
 class Test2ViewSet(PermissionViewMixin, VisibilityViewMixin, ModelViewSet):
     serializer_class = serializers.TestModel2Serializer
     queryset = models.Model2.objects.all()
+
+
+class TestBaseViewSet(PermissionViewMixin, VisibilityViewMixin, ModelViewSet):
+    permission_classes = [BaseDenyAll]
+    serializer_class = serializers.TestModel1Serializer
+    queryset = models.Model1.objects.all()


### PR DESCRIPTION
Currently we first check the generic permissions and the the views actual base permission. This doesn't make sense as we should first check e.g. whether a user is even authenticated before checking more specific permissions.